### PR TITLE
feat: support fm21

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,12 +3,14 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::Path;
 
-use quick_xml::events::BytesStart;
-use quick_xml::Reader;
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::reader::Reader;
 use regex::Regex;
 
 use crate::utils::attributes::get_attributes;
-use crate::utils::xml_utils::element_to_string;
+use crate::utils::xml_utils::{
+    element_to_string, end_element_to_string, start_element_to_string, text_element_to_string,
+};
 use crate::{escape_filename, join_scope_id_and_name, should_skip_line};
 
 pub(crate) mod attributes;
@@ -28,8 +30,7 @@ impl Entity {
         self.content.clear();
     }
 
-    pub fn read_xml_element<R: Read + BufRead>(&mut self, reader: &mut Reader<R>, e: &BytesStart) {
-        self.clear();
+    fn parse_xml_attributes(&mut self, e: &BytesStart) {
         for attr in get_attributes(e).unwrap() {
             match attr.0.as_str() {
                 "id" => self.id = attr.1.to_string(),
@@ -42,7 +43,37 @@ impl Entity {
                 _ => {}
             }
         }
-        self.content = element_to_string(reader, e);
+    }
+
+    pub fn read_xml_element<R: Read + BufRead>(&mut self, reader: &mut Reader<R>, e: &BytesStart) {
+        // self.clear();
+        self.parse_xml_attributes(e);
+
+        if self.id.is_empty() {
+            self.content = start_element_to_string(e);
+            let mut buf = Vec::new();
+            loop {
+                match reader.read_event_into(&mut buf) {
+                    Ok(Event::Start(e)) => {
+                        self.read_xml_element(reader, &e);
+                    }
+                    Ok(Event::Text(e)) => {
+                        self.content += text_element_to_string(&e, false).as_str();
+                    }
+                    Ok(Event::End(e)) => {
+                        self.content += end_element_to_string(&e).as_str();
+                        break;
+                    }
+                    Ok(Event::Eof) => break,
+                    unknown_event => {
+                        panic!("Wrong read event: {:?}", unknown_event);
+                    }
+                };
+                buf.clear();
+            }
+        } else {
+            self.content += element_to_string(reader, e).as_str();
+        }
     }
 }
 


### PR DESCRIPTION
More information: https://help.claris.com/en/pro-release-notes/content/index.html

> The corresponding value list in the ValueListCatalog element now contains only an id, name, UUID, and source type. The details about the value list are now stored in the new OptionsForValueLists element.