### PR TITLE
feat: added flag to parse all lines instead of skipping some

### DIFF
--- a/src/custom_menu_catalog.rs
+++ b/src/custom_menu_catalog.rs
@@ -6,12 +6,14 @@ use quick_xml::reader::Reader;
 
 use crate::utils::xml_utils::skip_element;
 use crate::utils::{initialize_out_dir, write_xml_element_to_file};
+use crate::Flags;
 
 pub fn xml_explode_custom_menu_catalog<R: Read + BufRead>(
     reader: &mut Reader<R>,
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("custom_menus").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -29,7 +31,7 @@ pub fn xml_explode_custom_menu_catalog<R: Read + BufRead>(
                 depth += 1;
                 if depth == 2 {
                     if e.name().as_ref() == b"CustomMenu" {
-                        write_xml_element_to_file(reader, &e, &out_dir_path, 4);
+                        write_xml_element_to_file(reader, &e, &out_dir_path, 4, flags);
                         depth -= 1;
                         continue;
                     } else {

--- a/src/custom_menu_set_catalog.rs
+++ b/src/custom_menu_set_catalog.rs
@@ -6,12 +6,14 @@ use quick_xml::reader::Reader;
 
 use crate::utils::xml_utils::skip_element;
 use crate::utils::{initialize_out_dir, write_xml_element_to_file};
+use crate::Flags;
 
 pub fn xml_explode_custom_menu_set_catalog<R: Read + BufRead>(
     reader: &mut Reader<R>,
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("custom_menu_sets").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -29,7 +31,7 @@ pub fn xml_explode_custom_menu_set_catalog<R: Read + BufRead>(
                 depth += 1;
                 if depth == 3 {
                     if e.name().as_ref() == b"CustomMenuSet" {
-                        write_xml_element_to_file(reader, &e, &out_dir_path, 5);
+                        write_xml_element_to_file(reader, &e, &out_dir_path, 5, flags);
                         depth -= 1;
                         continue;
                     } else {

--- a/src/extended_privileges_catalog.rs
+++ b/src/extended_privileges_catalog.rs
@@ -6,12 +6,14 @@ use quick_xml::reader::Reader;
 
 use crate::utils::xml_utils::skip_element;
 use crate::utils::{initialize_out_dir, write_xml_element_to_file};
+use crate::Flags;
 
 pub fn xml_explode_extended_privileges_catalog<R: Read + BufRead>(
     reader: &mut Reader<R>,
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("extended_privileges").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -29,7 +31,7 @@ pub fn xml_explode_extended_privileges_catalog<R: Read + BufRead>(
                 depth += 1;
                 if depth == 3 {
                     if e.name().as_ref() == b"ExtendedPrivilege" {
-                        write_xml_element_to_file(reader, &e, &out_dir_path, 5);
+                        write_xml_element_to_file(reader, &e, &out_dir_path, 5, flags);
                         depth -= 1;
                         continue;
                     } else {

--- a/src/external_data_source_catalog.rs
+++ b/src/external_data_source_catalog.rs
@@ -8,12 +8,14 @@ use crate::utils::xml_utils::{
     cdata_element_to_string, end_element_to_string, start_element_to_string, text_element_to_string,
 };
 use crate::utils::{create_dir, write_xml_file};
+use crate::Flags;
 
 pub fn xml_extract_external_data_sources<R: Read + BufRead>(
     reader: &mut Reader<R>,
     start: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("external_data_sources");
     create_dir(&out_dir_path);
@@ -43,6 +45,7 @@ pub fn xml_extract_external_data_sources<R: Read + BufRead>(
                         &out_dir_path,
                         fm_file_name,
                         &external_data_source_info,
+                        flags,
                     );
                     break;
                 }
@@ -63,7 +66,12 @@ pub fn xml_extract_external_data_sources<R: Read + BufRead>(
     }
 }
 
-fn write_external_data_sources_to_file(output_dir: &Path, fm_file_name: &str, content: &str) {
+fn write_external_data_sources_to_file(
+    output_dir: &Path,
+    fm_file_name: &str,
+    content: &str,
+    flags: &Flags,
+) {
     let output_file_path = output_dir.join(format!("{}.xml", fm_file_name));
-    write_xml_file(&output_file_path, content, 3);
+    write_xml_file(&output_file_path, content, 3, flags);
 }

--- a/src/layout_catalog.rs
+++ b/src/layout_catalog.rs
@@ -12,6 +12,7 @@ use crate::utils::xml_utils::{
     start_element_to_string, text_element_to_string,
 };
 use crate::utils::{initialize_out_dir, write_xml_file};
+use crate::Flags;
 use crate::{escape_filename, join_scope_id_and_name};
 
 #[derive(Debug, Default)]
@@ -27,6 +28,7 @@ pub fn xml_explode_layout_catalog<R: Read + BufRead>(
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("layouts").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -106,7 +108,7 @@ pub fn xml_explode_layout_catalog<R: Read + BufRead>(
                     .push_str(end_element_to_string(&e).as_str());
 
                 if depth == 1 && local_name_to_string(e.name().as_ref()) == "Layout" {
-                    write_layout_to_file(&out_dir_path, &layout_info)
+                    write_layout_to_file(&out_dir_path, &layout_info, flags)
                 }
             }
             Ok(Event::CData(e)) => {
@@ -131,7 +133,7 @@ pub fn xml_explode_layout_catalog<R: Read + BufRead>(
     }
 }
 
-fn write_layout_to_file(dir_path: &Path, layout: &LayoutInfo) {
+fn write_layout_to_file(dir_path: &Path, layout: &LayoutInfo, flags: &Flags) {
     let layout_filename = join_scope_id_and_name(layout.id.as_str(), layout.name.as_str());
     let layout_filename = escape_filename(&layout_filename);
 
@@ -148,5 +150,5 @@ fn write_layout_to_file(dir_path: &Path, layout: &LayoutInfo) {
         .unwrap_or_else(|err| panic!("Error creating directory {}: {}", output_dir.display(), err));
 
     let output_file_path = output_dir.join(format!("{}.xml", layout_filename));
-    write_xml_file(&output_file_path, &layout.content, 4);
+    write_xml_file(&output_file_path, &layout.content, 4, flags);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ struct Args {
     /// The target directory to write output
     target: PathBuf,
 
-    /// Should all lines be parsed, or is it ok to skip less important ones?
+    /// Parse all lines (or skip less important ones to reduce noise)
     #[arg(short, long)]
     all_lines: bool,
 }

--- a/src/privilege_sets_catalog.rs
+++ b/src/privilege_sets_catalog.rs
@@ -6,12 +6,14 @@ use quick_xml::reader::Reader;
 
 use crate::utils::xml_utils::skip_element;
 use crate::utils::{initialize_out_dir, write_xml_element_to_file};
+use crate::Flags;
 
 pub fn xml_explode_privilege_set_catalog<R: Read + BufRead>(
     reader: &mut Reader<R>,
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("privilege_sets").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -29,7 +31,7 @@ pub fn xml_explode_privilege_set_catalog<R: Read + BufRead>(
                 depth += 1;
                 if depth == 3 {
                     if e.name().as_ref() == b"PrivilegeSet" {
-                        write_xml_element_to_file(reader, &e, &out_dir_path, 5);
+                        write_xml_element_to_file(reader, &e, &out_dir_path, 5, flags);
                         depth -= 1;
                         continue;
                     } else {

--- a/src/relationship_catalog.rs
+++ b/src/relationship_catalog.rs
@@ -10,6 +10,7 @@ use crate::utils::xml_utils::{
     start_element_to_string, text_element_to_string,
 };
 use crate::utils::{initialize_out_dir, write_xml_file};
+use crate::Flags;
 use crate::{escape_filename, join_scope_id_and_name};
 
 #[derive(Debug, Default)]
@@ -25,6 +26,7 @@ pub fn xml_explode_relationship_catalog<R: Read + BufRead>(
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("relationships").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -95,7 +97,7 @@ pub fn xml_explode_relationship_catalog<R: Read + BufRead>(
                     .push_str(end_element_to_string(&e).as_str());
 
                 if depth == 1 && local_name_to_string(e.name().as_ref()) == "Relationship" {
-                    write_relationship_to_file(&out_dir_path, &relationship_info);
+                    write_relationship_to_file(&out_dir_path, &relationship_info, flags);
                     relationship_info.id.clear();
                     relationship_info.left.clear();
                     relationship_info.right.clear();
@@ -133,12 +135,12 @@ pub fn xml_explode_relationship_catalog<R: Read + BufRead>(
     }
 }
 
-fn write_relationship_to_file(output_dir: &Path, relationship: &RelationshipInfo) {
+fn write_relationship_to_file(output_dir: &Path, relationship: &RelationshipInfo, flags: &Flags) {
     let relationship_filename = join_scope_id_and_name(
         relationship.id.as_str(),
         format!("[{}] - [{}]", relationship.left, relationship.right).as_str(),
     );
     let relationship_filename = escape_filename(&relationship_filename).replace('.', "_");
     let output_file_path = output_dir.join(format!("{}.xml", relationship_filename));
-    write_xml_file(&output_file_path, &relationship.content, 4);
+    write_xml_file(&output_file_path, &relationship.content, 4, flags);
 }

--- a/src/script_steps_catalog.rs
+++ b/src/script_steps_catalog.rs
@@ -15,6 +15,7 @@ use crate::utils::xml_utils::{
     text_element_to_string,
 };
 use crate::utils::{initialize_out_dir, write_text_file, write_xml_file};
+use crate::Flags;
 use crate::{escape_filename, join_scope_id_and_name};
 
 #[derive(Debug, Default)]
@@ -40,6 +41,7 @@ pub fn xml_explode_script_catalog<R: Read + BufRead>(
     out_dir_path: &Path,
     fm_file_name: &str,
     script_id_path_map: &HashMap<String, Vec<String>>,
+    flags: &Flags,
 ) {
     let scripts_xml_out_dir_path = out_dir_path.join("scripts").join(fm_file_name);
     let scripts_text_out_dir_path = out_dir_path.join("scripts_sanitized").join(fm_file_name);
@@ -127,7 +129,7 @@ pub fn xml_explode_script_catalog<R: Read + BufRead>(
                 script_info.xml.push_str(end_element_to_string(&e).as_str());
 
                 if depth == 1 && e.name().as_ref() == b"Script" {
-                    write_script_to_file(out_dir_path, fm_file_name, &script_info);
+                    write_script_to_file(out_dir_path, fm_file_name, &script_info, flags);
                     script_info.id.clear();
                     script_info.name.clear();
                     script_info.text.clear();
@@ -199,7 +201,7 @@ pub fn xml_explode_script_catalog<R: Read + BufRead>(
     }
 }
 
-fn write_script_to_file(dir_path: &Path, fm_file_name: &str, script: &ScriptInfo) {
+fn write_script_to_file(dir_path: &Path, fm_file_name: &str, script: &ScriptInfo, flags: &Flags) {
     let script_filename = join_scope_id_and_name(script.id.as_str(), script.name.as_str());
     let script_filename = escape_filename(&script_filename);
 
@@ -222,7 +224,7 @@ fn write_script_to_file(dir_path: &Path, fm_file_name: &str, script: &ScriptInfo
             err
         )
     });
-    write_script_to_xml_file(&xml_output_dir, &script_filename, &script.xml);
+    write_script_to_xml_file(&xml_output_dir, &script_filename, &script.xml, flags);
 
     let txt_output_dir = dir_path
         .join("scripts_sanitized")
@@ -238,9 +240,14 @@ fn write_script_to_file(dir_path: &Path, fm_file_name: &str, script: &ScriptInfo
     write_script_to_text_file(&txt_output_dir, &script_filename, &script.text);
 }
 
-fn write_script_to_xml_file(output_dir: &Path, script_filename: &str, content: &str) {
+fn write_script_to_xml_file(
+    output_dir: &Path,
+    script_filename: &str,
+    content: &str,
+    flags: &Flags,
+) {
     let output_file_path = output_dir.join(format!("{}.xml", script_filename));
-    write_xml_file(&output_file_path, content, 4);
+    write_xml_file(&output_file_path, content, 4, flags);
 }
 
 fn write_script_to_text_file(output_dir: &Path, script_filename: &str, content: &str) {

--- a/src/table_catalog.rs
+++ b/src/table_catalog.rs
@@ -11,6 +11,7 @@ use crate::utils::xml_utils::{
     text_element_to_string,
 };
 use crate::utils::{initialize_out_dir, write_xml_file, Entity};
+use crate::Flags;
 use crate::{escape_filename, join_scope_id_and_name};
 
 pub fn xml_explode_table_catalog<R: Read + BufRead>(
@@ -19,6 +20,7 @@ pub fn xml_explode_table_catalog<R: Read + BufRead>(
     out_dir_path: &Path,
     fm_file_name: &str,
     table_name_id_map: &HashMap<String, String>,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("tables").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -80,7 +82,7 @@ pub fn xml_explode_table_catalog<R: Read + BufRead>(
                     .push_str(end_element_to_string(&e).as_str());
 
                 if depth == 1 && local_name_to_string(e.name().as_ref()) == "FieldCatalog" {
-                    write_table_to_file(&out_dir_path, &table_info);
+                    write_table_to_file(&out_dir_path, &table_info, flags);
                     table_info.clear();
                 }
             }
@@ -106,9 +108,9 @@ pub fn xml_explode_table_catalog<R: Read + BufRead>(
     }
 }
 
-fn write_table_to_file(output_dir: &Path, table: &Entity) {
+fn write_table_to_file(output_dir: &Path, table: &Entity, flags: &Flags) {
     let table_filename = join_scope_id_and_name(table.id.as_str(), table.name.as_str());
     let table_filename = escape_filename(&table_filename);
     let output_file_path = output_dir.join(format!("{}.xml", table_filename));
-    write_xml_file(&output_file_path, &table.content, 4);
+    write_xml_file(&output_file_path, &table.content, 4, flags);
 }

--- a/src/table_occurrence_catalog.rs
+++ b/src/table_occurrence_catalog.rs
@@ -6,12 +6,14 @@ use quick_xml::reader::Reader;
 
 use crate::utils::xml_utils::skip_element;
 use crate::utils::{initialize_out_dir, write_xml_element_to_file};
+use crate::Flags;
 
 pub fn xml_explode_table_occurrence_catalog<R: Read + BufRead>(
     reader: &mut Reader<R>,
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("table_occurrences").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -29,7 +31,7 @@ pub fn xml_explode_table_occurrence_catalog<R: Read + BufRead>(
                 depth += 1;
                 if depth == 2 {
                     if e.name().as_ref() == b"TableOccurrence" {
-                        write_xml_element_to_file(reader, &e, &out_dir_path, 4);
+                        write_xml_element_to_file(reader, &e, &out_dir_path, 4, flags);
                         depth -= 1;
                     } else {
                         skip_element(reader, &e);

--- a/src/theme_catalog.rs
+++ b/src/theme_catalog.rs
@@ -6,12 +6,14 @@ use quick_xml::reader::Reader;
 
 use crate::utils::xml_utils::skip_element;
 use crate::utils::{initialize_out_dir, write_xml_element_to_file};
+use crate::Flags;
 
 pub fn xml_explode_theme_catalog<R: Read + BufRead>(
     reader: &mut Reader<R>,
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("themes").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -29,7 +31,7 @@ pub fn xml_explode_theme_catalog<R: Read + BufRead>(
                 depth += 1;
                 if depth == 2 {
                     if e.name().as_ref() == b"Theme" {
-                        write_xml_element_to_file(reader, &e, &out_dir_path, 4);
+                        write_xml_element_to_file(reader, &e, &out_dir_path, 4, flags);
                         depth -= 1;
                     } else {
                         skip_element(reader, &e);

--- a/src/value_list_catalog.rs
+++ b/src/value_list_catalog.rs
@@ -6,12 +6,14 @@ use quick_xml::reader::Reader;
 
 use crate::utils::xml_utils::skip_element;
 use crate::utils::{initialize_out_dir, write_xml_element_to_file};
+use crate::Flags;
 
 pub fn xml_explode_value_list_catalog<R: Read + BufRead>(
     reader: &mut Reader<R>,
     _: &BytesStart,
     out_dir_path: &Path,
     fm_file_name: &str,
+    flags: &Flags,
 ) {
     let out_dir_path = out_dir_path.join("value_lists").join(fm_file_name);
     initialize_out_dir(&out_dir_path);
@@ -29,7 +31,7 @@ pub fn xml_explode_value_list_catalog<R: Read + BufRead>(
                 depth += 1;
                 if depth == 2 {
                     if e.name().as_ref() == b"ValueList" {
-                        write_xml_element_to_file(reader, &e, &out_dir_path, 4);
+                        write_xml_element_to_file(reader, &e, &out_dir_path, 4, flags);
                         depth -= 1;
                     } else {
                         skip_element(reader, &e);


### PR DESCRIPTION
Thank you for creating this repo and making it publicly available. This PR is implementing a TO DO that was left in the should_skip_line function. Currently certain lines are skipped while parsing the full XML file with the goal of "de-noising" the output files. Now there is a new argument, an optional --all-lines flag, which, when used, will skip the should_skip_line function, i.e. all lines will be parsed. I ran the test to do regression testing for when the --all-lines flag is not specified. I did not add a new test for the new flag though. Lmk if you'd like me to do that.