### PR TITLE
fix: strip Collapsed attribute from sanitized output

### DIFF
--- a/src/script_steps/parameters/boolean.rs
+++ b/src/script_steps/parameters/boolean.rs
@@ -86,6 +86,11 @@ impl Boolean {
     }
 
     pub fn display(self) -> Option<String> {
+        // Collapsed is a UI-only flag (Script Workspace visual state) — never shown in output
+        if self.name.as_deref() == Some("Collapsed") {
+            return None;
+        }
+
         if self.should_hide_bool() {
             // Hidden booleans only show their name when the value is true
             return self.value.filter(|&v| v).and(self.name);
@@ -127,6 +132,27 @@ mod tests {
                 .display()
                 .unwrap(),
             expected_output
+        );
+    }
+
+    #[test]
+    fn test_collapsed_returns_none() {
+        let xml = r#"
+            <Parameter type="Boolean">
+                <Boolean type="Collapsed" id="0" value="False"></Boolean>
+            </Parameter>
+        "#;
+
+        let mut reader = Reader::from_str(xml.trim());
+        let element = match reader.read_event() {
+            Ok(Event::Start(e)) => e,
+            _ => panic!("Wrong read event"),
+        };
+
+        assert_eq!(
+            Boolean::from_xml(&mut reader, &element, 0).display(),
+            None,
+            "Collapsed boolean should produce no output"
         );
     }
 

--- a/src/utils/xml_utils.rs
+++ b/src/utils/xml_utils.rs
@@ -29,7 +29,12 @@ pub fn start_element_to_string(e: &BytesStart, flags: &Flags) -> String {
     complete_tag.push_str(&local_name_to_string(e.name().as_ref()));
 
     for attr in get_attributes(e) {
-        if !flags.lossless && matches!(attr.0.as_str(), "nextvalue" | "UUID" | "index") {
+        if !flags.lossless
+            && matches!(
+                attr.0.as_str(),
+                "nextvalue" | "UUID" | "index" | "Collapsed"
+            )
+        {
             continue;
         }
         complete_tag.push(' ');

--- a/tests/snapshots_db_lossless/Ooe/scripts_sanitized/SaXMLDelivery - ID 50/saxmlDelivery_createXml - ID 51.txt.snap
+++ b/tests/snapshots_db_lossless/Ooe/scripts_sanitized/SaXMLDelivery - ID 50/saxmlDelivery_createXml - ID 51.txt.snap
@@ -52,18 +52,18 @@ Set Variable [ $message ; "" ]
 Set Variable [ $data ; "{}" ]
 
 # Send script to server via PSoS
-If [ Collapsed: OFF ; PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 // if not already running on fmse ]
+If [ PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 // if not already running on fmse ]
 	# Only try to do this if file is hosted
-	If [ Collapsed: OFF ; Get ( ConnectionState ) ≠ 0 ]
+	If [ Get ( ConnectionState ) ≠ 0 ]
 		Perform Script on Server [ By name ; ⚠️ PARAMETER "Parameter" NOT PARSED ⚠️ ; Wait for completion: ON ]
 		Set Variable [ $errorCode ; Get ( LastError ) ]
 		Set Variable [ $recordId ; JSONGetElement ( Get ( ScriptResult ) ; "data.recordId" ) ]
-		If [ Collapsed: OFF ; $errorCode = 0 and not IsEmpty ( $recordId ) ]
+		If [ $errorCode = 0 and not IsEmpty ( $recordId ) ]
 			Enter Find Mode [ Pause: OFF ]
 			Go to Layout [ Layout: "SaXMLDeliveryExecutionContext" ; Animation: None ]
 			Set Field [ SaXMLDelivery::recordId ; $recordId ]
 			Perform Find
-		Else [ Collapsed: OFF ; Collapsed: OFF ]
+		Else
 			Go to Layout [ Layout: "SaXMLDeliveryExecutionContext" ; Animation: None ]
 			Show All Records
 			Show Omitted Only
@@ -75,7 +75,7 @@ End If
 # Validate privilege set - must be full access or must have access via the Data API
 # ■■■■■■■■■■ CONFIGURATION STEP (optional): Customize restrictions to run this script
 Set Variable [ $allowedPrivilegeSet ; Get ( AccountPrivilegeSetName ) = "[Full Access]" or not IsEmpty ( FilterValues ( Get ( AccountExtendedPrivileges ) ; "fmrest" ) ) ]
-If [ Collapsed: OFF ; not $allowedPrivilegeSet ]
+If [ not $allowedPrivilegeSet ]
 	Exit Script [ JSONSetElement ( "" ; [ "errorCode" ; 9 ; JSONNumber ] ; [ "message" ; "Insufficient privileges" ; JSONString ] ) ]
 End If
 
@@ -112,13 +112,13 @@ Set Error Capture [ ON ]
 # ====================================================================================================
 
 # Set up context
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Go to Layout [ Layout: "SaXMLDeliveryExecutionContext" ; Animation: None ]
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 End If
 
 # Purge old records
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	# Delete records older than 3 months
 	Set Variable [ $purgeDate[1] ; Let ( 
 	today = Get ( CurrentDate ) ; 
@@ -127,25 +127,25 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 	Enter Find Mode [ Pause: OFF ]
 	Set Field [ SaXMLDelivery::createTimestamp ; "<" & $purgeDate ]
 	Perform Find
-	If [ Collapsed: OFF ; Get ( FoundCount ) > 0 and Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) // belt and suspenders ]
+	If [ Get ( FoundCount ) > 0 and Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) // belt and suspenders ]
 		Delete All Records [ With dialog: OFF ]
 	End If
 End If
 
 # Create new record
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	New Record/Request
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 End If
 
 # Create SaXML xml file on file system
 # 2024-10-07 mkos: Added support for $_includeDetailsForAnalysisTools
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Set Variable [ $xmlPath ; Get ( TemporaryPath ) & Get ( FileName ) & ".xml" ]
 	Set Variable [ $start ; Get ( CurrentTimeUTCMilliseconds ) ]
-	If [ Collapsed: OFF ; $_includeDetailsForAnalysisTools ]
+	If [ $_includeDetailsForAnalysisTools ]
 		Save a Copy as XML [ Get ( WindowName ) ; ⚠️ PARAMETER "UniversalPathList" NOT PARSED ⚠️ ; Include details for analysis tools: ON ; Save each layout object&apos;s binary data under its node: OFF ]
-	Else [ Collapsed: OFF ; Collapsed: OFF ]
+	Else
 		Save a Copy as XML [ Get ( WindowName ) ; ⚠️ PARAMETER "UniversalPathList" NOT PARSED ⚠️ ; Include details for analysis tools: OFF ; Save each layout object&apos;s binary data under its node: OFF ]
 	End If
 	Set Variable [ $errorCode ; Get ( LastError ) ]
@@ -155,13 +155,13 @@ End If
 # Upload xml file to container field
 # Note, we tried using the Read From Data File step, but it's not any faster, and it makes the code more complex, bc you have to read the file in chunks
 # 2024-07-17 mkos: Don't automatically encode url since ConvertFromFileMakerPath will already do that for us
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Set Variable [ $start ; Get ( CurrentTimeUTCMilliseconds ) ]
 	Insert from URL [ Verify SSL Certificates: OFF ; Select: ON ; With dialog: OFF ; Target: SaXMLDelivery::xmlFile ; ⚠️ PARAMETER "URL" NOT PARSED ⚠️ ]
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 	Set Variable [ $timeToUpload[1] ; GetAsTime ( ( Get ( CurrentTimeUTCMilliseconds ) - $start ) / 1000 ) ]
 End If
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Set Field [ SaXMLDelivery::timeToCreate ; $timeToCreate ]
 	Set Field [ SaXMLDelivery::timeToUpload ; $timeToUpload ]
 	Set Field [ SaXMLDelivery::sizeInBytes ; GetContainerAttribute ( SaXMLDelivery::xmlFile ; "filesize" ) ]
@@ -171,13 +171,13 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 End If
 
 # Delete xml file in temp folder
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Delete File [ ⚠️ PARAMETER "UniversalPathList" NOT PARSED ⚠️ ]
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 End If
 
 # Handle error
-If [ Collapsed: OFF ; $errorCode > 1 and IsEmpty ( $message ) ]
+If [ $errorCode > 1 and IsEmpty ( $message ) ]
 	Set Variable [ $message[1] ; // We would typically use a custom function here, but we wanted this script to have as few dependencies as possible
 /**
  * @SIGNATURE:
@@ -487,7 +487,7 @@ Let ( [
 	
 ) ]
 End If
-If [ Collapsed: OFF ; not IsEmpty ( $message )
+If [ not IsEmpty ( $message )
 and PatternCount ( Get ( ApplicationVersion ) ; "Data API Engine" ) = 0
 and PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 ]
 	Show Custom Dialog [ Message: $message ; Default Button: "OK" ]
@@ -504,8 +504,8 @@ Set Variable [ $data[1] ; JSONSetElement ( $data
 Set Variable [ $result[1] ; JSONSetElement ( "" ; [ "errorCode" ; $errorCode ; JSONNumber ] ; [ "message" ; $message ; JSONString ] ; [ "data" ; $data ; JSONObject ] ) ]
 
 # In case of error, if we were able to get to the layout and create a new record, store $result in the record
-If [ Collapsed: OFF ; $errorCode > 1 ]
-	If [ Collapsed: OFF ; Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) and not IsEmpty ( $recordId ) ]
+If [ $errorCode > 1 ]
+	If [ Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) and not IsEmpty ( $recordId ) ]
 		Set Field [ SaXMLDelivery::notes ; Get ( ScriptName ) & " script result:¶" & JSONFormatElements ( $result ) ]
 		Commit Records/Requests [ Skip data entry validation ; With dialog: OFF ]
 	End If
@@ -515,9 +515,9 @@ End If
 # END
 # ====================================================================================================
 
-If [ Collapsed: OFF ; $parentScriptErrorCaptureState ]
+If [ $parentScriptErrorCaptureState ]
 	Set Error Capture [ OFF ]
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+Else
 	Set Error Capture [ OFF ]
 End If
 

--- a/tests/snapshots_db_lossless/Ooe/scripts_sanitized/SaXMLDelivery - ID 50/saxmlDelivery_runPipeline - ID 53.txt.snap
+++ b/tests/snapshots_db_lossless/Ooe/scripts_sanitized/SaXMLDelivery - ID 50/saxmlDelivery_runPipeline - ID 53.txt.snap
@@ -44,7 +44,7 @@ Set Variable [ $_silent[1] ; If (
 
 # Validate privilege set - must be full access
 # ■■■■■■■■■■ CONFIGURATION STEP (optional): Customize restrictions to run this script
-If [ Collapsed: OFF ; Get ( AccountPrivilegeSetName ) ≠ "[Full Access]" ]
+If [ Get ( AccountPrivilegeSetName ) ≠ "[Full Access]" ]
 	Exit Script [ JSONSetElement ( "" ; [ "errorCode" ; 9 ; JSONNumber ] ; [ "message" ; "Insufficient privileges" ; JSONString ] ) ]
 End If
 
@@ -82,16 +82,16 @@ Set Variable [ $missingRequired[1] ; List (
 	If ( IsEmpty ( $owner ) ; "git account owner" ) ; 
 	If ( IsEmpty ( FilterValues ( $gitService ; "Bitbucket¶GitHub" ) ) ; "git hosting service" ) ; 
 ) ]
-If [ Collapsed: OFF ; not IsEmpty ( $missingRequired ) ]
+If [ not IsEmpty ( $missingRequired ) ]
 	Set Variable [ $errorCode[1] ; 5 ]
 	Set Variable [ $message[1] ; "Missing config: " & Substitute ( $missingRequired ; ¶ ; ", " ) & "." ]
 End If
 
 # Confirm action
-If [ Collapsed: OFF ; $errorCode = 0 ]
-	If [ Collapsed: OFF ; not $_silent ]
+If [ $errorCode = 0 ]
+	If [ not $_silent ]
 		Show Custom Dialog [ Message: "Run " & $repoName & " pipeline?" ; Default Button: "OK" ; Button 2: "Cancel" ]
-		If [ Collapsed: OFF ; Get ( LastMessageChoice ) ≠ 1 ]
+		If [ Get ( LastMessageChoice ) ≠ 1 ]
 			Set Variable [ $errorCode[1] ; 1 ]
 		End If
 	End If
@@ -99,8 +99,8 @@ End If
 
 # Prep api call
 # 2024-10-07 mkos: @todo add support for an 'includeDetailsForAnalysisTools' parameter by forwarding it to the bitbucket api
-If [ Collapsed: OFF ; $errorCode = 0 ]
-	If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+If [ $errorCode = 0 ]
+	If [ $gitService = "Bitbucket" ]
 		# ref: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pipelines/#api-repositories-workspace-repo-slug-pipelines-post
 		Set Variable [ $url[1] ; "https://api.bitbucket.org/2.0/repositories/" & $owner & "/" & $repoName & "/pipelines" ]
 		Set Variable [ $requestBody[1] ; JSONSetElement ( "" 
@@ -116,7 +116,7 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 & " --header " & Quote ( "Content-Type: application/json" ) 
 & " --data @$requestBody"
 & " --dump-header $responseHeaders" ]
-	Else [ Collapsed: OFF ; Collapsed: OFF ]
+	Else
 		# GitHub
 		Set Variable [ $url[1] ; "https://api.github.com/repos/" & $owner & "/" & $repoName & "/dispatches" ]
 		Set Variable [ $requestBody[1] ; JSONSetElement ( "" 
@@ -133,7 +133,7 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 End If
 
 # Make api call to trigger pipeline
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Insert from URL [ Verify SSL Certificates: ON ; Select: ON ; With dialog: OFF ; Target: $response ; ⚠️ PARAMETER "URL" NOT PARSED ⚠️ ; $curlOptions ]
 	Set Variable [ $errorCode[1] ; Get ( LastError ) ]
 	Set Variable [ $responseStatusCode[1] ; // We would typically use a custom function here, but we wanted this script to have as few dependencies as possible
@@ -169,7 +169,7 @@ Let ( [
 	GetAsNumber ( code )
 ) ]
 	Set Variable [ $isErrorResponseStatusCode[1] ; not IsEmpty ( $responseStatusCode ) and ( $responseStatusCode < 200 or $responseStatusCode > 299 ) ]
-	If [ Collapsed: OFF ; $gitService = "GitHub" and $errorCode = 10 and not $isErrorResponseStatusCode ]
+	If [ $gitService = "GitHub" and $errorCode = 10 and not $isErrorResponseStatusCode ]
 		# (10) Requested data is missing is expected with GitHub because they do not return a response body
 		Set Variable [ $errorCode[1] ; 0 // reset ]
 	End If
@@ -284,8 +284,8 @@ Let ( [
 End If
 
 # Extract info from success response
-If [ Collapsed: OFF ; $errorCode = 0 and not $isErrorResponseStatusCode ]
-	If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+If [ $errorCode = 0 and not $isErrorResponseStatusCode ]
+	If [ $gitService = "Bitbucket" ]
 		Set Variable [ $buildNumber[1] ; JSONGetElement ( $response ; "build_number" ) ]
 		Set Variable [ $createdOn[1] ; JSONGetElement ( $response ; "created_on" ) ]
 		Set Variable [ $repoUrl[1] ; JSONGetElement ( $response ; "repository.links.html.href" ) ]
@@ -293,8 +293,8 @@ If [ Collapsed: OFF ; $errorCode = 0 and not $isErrorResponseStatusCode ]
 End If
 
 # Build error $message
-If [ Collapsed: OFF ; IsEmpty ( $message ) ]
-	If [ Collapsed: OFF ; $errorCode > 1 ]
+If [ IsEmpty ( $message ) ]
+	If [ $errorCode > 1 ]
 		Set Variable [ $message[1] ; // We would typically use a custom function here, but we wanted this script to have as few dependencies as possible
 /**
  * @SIGNATURE:
@@ -603,7 +603,7 @@ Let ( [
 	"(" & errorCode & ") " & errorMessage 
 	
 ) ]
-	Else If [ Collapsed: OFF ; $isErrorResponseStatusCode ]
+	Else If [ $isErrorResponseStatusCode ]
 		Set Variable [ $errorCode[1] ; 999 & $responseStatusCode ]
 		Set Variable [ $responseStatusMessage[1] ; "(" & $responseStatusCode & ") " & Let ( 
 
@@ -728,29 +728,29 @@ Let ( [
 End If
 
 # Display $message
-If [ Collapsed: OFF ; not $_silent 
+If [ not $_silent 
 and PatternCount ( Get ( ApplicationVersion ) ; "Data API Engine" ) = 0 
 and PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 ]
-	If [ Collapsed: OFF ; $errorCode = 0 ]
-		If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+	If [ $errorCode = 0 ]
+		If [ $gitService = "Bitbucket" ]
 			Set Variable [ $message[1] ; "The " & Quote ( $repoName ) & " pipeline is running build # " & $buildNumber & ". View in browser?" ]
 			Show Custom Dialog [ Message: $message ; Default Button: "Dismiss" ; Button 2: "View" ]
-			If [ Collapsed: OFF ; Get ( LastMessageChoice ) = 2 ]
+			If [ Get ( LastMessageChoice ) = 2 ]
 				Set Variable [ $pipelineBuildUrl[1] ; $repoUrl & "/pipelines/results/" & $buildNumber ]
 				Open URL [ In external browser: OFF ; With dialog: OFF ; ⚠️ PARAMETER "URL" NOT PARSED ⚠️ ]
 			End If
-		Else [ Collapsed: OFF ; Collapsed: OFF ]
+		Else
 			# GitHub
 			Show Custom Dialog [ Message: "The " & Quote ( $repoName ) & " pipeline is running." ; Default Button: "OK" ]
 		End If
-	Else If [ Collapsed: OFF ; not IsEmpty ( $message ) ]
+	Else If [ not IsEmpty ( $message ) ]
 		Show Custom Dialog [ Title: "Error" ; Message: $message ; Default Button: "OK" ]
 	End If
 End If
 
 # Build $data
-If [ Collapsed: OFF ; $errorCode = 0 ]
-	If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+If [ $errorCode = 0 ]
+	If [ $gitService = "Bitbucket" ]
 		Set Variable [ $data[1] ; JSONSetElement ( $data 
 	; [ "buildNumber" ; $buildNumber ; JSONString ] 
 	; [ "createdOn" ; $createdOn ; JSONString ] 
@@ -764,9 +764,9 @@ End If
 # END
 # ====================================================================================================
 
-If [ Collapsed: OFF ; $parentScriptErrorCaptureState ]
+If [ $parentScriptErrorCaptureState ]
 	Set Error Capture [ OFF ]
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+Else
 	Set Error Capture [ OFF ]
 End If
 

--- a/tests/snapshots_db_lossless/Ooe/scripts_sanitized/Script from fmSyntaxColorizer - ID 37/All script steps and all options - ID 39.txt.snap
+++ b/tests/snapshots_db_lossless/Ooe/scripts_sanitized/Script from fmSyntaxColorizer - ID 37/All script steps and all options - ID 39.txt.snap
@@ -51,12 +51,12 @@ Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ;
 Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ; Name: 123 ; ⚠️ PARAMETER "UUID" NOT PARSED ⚠️ ]
 Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ; Name: $BeaconName ; ⚠️ PARAMETER "Latitude" NOT PARSED ⚠️ ; ⚠️ PARAMETER "Longitude" NOT PARSED ⚠️ ; ⚠️ PARAMETER "Radius" NOT PARSED ⚠️ ]
 
-If [ Collapsed: OFF ; 1=0 ]
-Else If [ Collapsed: OFF ; 1=1 ]
-	If [ Collapsed: OFF ]
-	Else If [ Collapsed: OFF ]
+If [ 1=0 ]
+Else If [ 1=1 ]
+	If []
+	Else If []
 	End If
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+Else
 End If
 
 Exit Script []
@@ -68,21 +68,21 @@ Install OnTimer Script
 Install OnTimer Script [ 123 ]
 Install OnTimer Script [ 1+2 ]
 
-Loop [ Collapsed: OFF ; Flush: Always ]
+Loop [ Flush: Always ]
 	Exit Loop If [ 1=1 ]
 End Loop
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 5000 ; ErrorMessage: "Broken" ]
 Commit Transaction
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: OFF ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: OFF ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 5000 ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 5000 ]
 Revert Transaction [ Condition: 1=1 ]
 Commit Transaction
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: ON ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: ON ]
 Revert Transaction [ ErrorCode: 5000 ; ErrorMessage: "Broken" ]
 Commit Transaction
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: ON ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: ON ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 1 ; ErrorMessage: "Broken" ]
 Commit Transaction
 
@@ -229,9 +229,9 @@ Select All
 
 Set Selection [ 🚨🚨🚨 BROKEN REFERENCE 🚨🚨🚨 ; ⚠️ PARAMETER "Select" NOT PARSED ⚠️ ]
 
-Undo/Redo [ Collapsed: OFF ; Toggle ]
-Undo/Redo [ Collapsed: OFF ; Undo ]
-Undo/Redo [ Collapsed: OFF ; Redo ]
+Undo/Redo [ Toggle ]
+Undo/Redo [ Undo ]
+Undo/Redo [ Redo ]
 
 # ===========
 # FIELD STEPS

--- a/tests/snapshots_db_lossless/Ooe/scripts_sanitized/Scripts With Everything - ID 21/Control - ID 20.txt.snap
+++ b/tests/snapshots_db_lossless/Ooe/scripts_sanitized/Scripts With Everything - ID 21/Control - ID 20.txt.snap
@@ -5,7 +5,7 @@ expression: output_content
 
 Allow User Abort [ OFF ]
 
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
 Set Revert Transaction on Error [ OFF ]
 Revert Transaction
 Commit Transaction
@@ -14,12 +14,12 @@ Configure Local Notification [ ⚠️ PARAMETER "action" NOT PARSED ⚠️ ]
 Configure NFC Reading [ ⚠️ PARAMETER "action" NOT PARSED ⚠️ ]
 Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ]
 
-If [ Collapsed: OFF ]
-Else If [ Collapsed: OFF ]
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+If []
+Else If []
+Else
 End If
 
-Loop [ Collapsed: OFF ; Flush: Always ]
+Loop [ Flush: Always ]
 	Exit Loop If [ True ]
 End Loop
 

--- a/tests/snapshots_db_lossless/Ooe/scripts_sanitized/Scripts With Everything - ID 21/Editing - ID 24.txt.snap
+++ b/tests/snapshots_db_lossless/Ooe/scripts_sanitized/Scripts With Everything - ID 21/Editing - ID 24.txt.snap
@@ -10,4 +10,4 @@ Paste [ Select: ON ; No style: ON ]
 Perform Find/Replace [ With dialog: ON ; ⚠️ PARAMETER "perform" NOT PARSED ⚠️ ; ⚠️ PARAMETER "find" NOT PARSED ⚠️ ; ⚠️ PARAMETER "replace" NOT PARSED ⚠️ ; ⚠️ PARAMETER "direction" NOT PARSED ⚠️ ; ⚠️ PARAMETER "case" NOT PARSED ⚠️ ; ⚠️ PARAMETER "whole" NOT PARSED ⚠️ ; ⚠️ PARAMETER "across" NOT PARSED ⚠️ ; ⚠️ PARAMETER "within" NOT PARSED ⚠️ ]
 Select All
 Set Selection [ ⚠️ PARAMETER "Select" NOT PARSED ⚠️ ]
-Undo/Redo [ Collapsed: OFF ; Undo ]
+Undo/Redo [ Undo ]

--- a/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/SaXMLDelivery - ID 50/saxmlDelivery_createXml - ID 51.txt.snap
+++ b/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/SaXMLDelivery - ID 50/saxmlDelivery_createXml - ID 51.txt.snap
@@ -52,18 +52,18 @@ Set Variable [ $message ; "" ]
 Set Variable [ $data ; "{}" ]
 
 # Send script to server via PSoS
-If [ Collapsed: OFF ; PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 // if not already running on fmse ]
+If [ PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 // if not already running on fmse ]
 	# Only try to do this if file is hosted
-	If [ Collapsed: OFF ; Get ( ConnectionState ) ≠ 0 ]
+	If [ Get ( ConnectionState ) ≠ 0 ]
 		Perform Script on Server [ By name ; ⚠️ PARAMETER "Parameter" NOT PARSED ⚠️ ; Wait for completion: ON ]
 		Set Variable [ $errorCode ; Get ( LastError ) ]
 		Set Variable [ $recordId ; JSONGetElement ( Get ( ScriptResult ) ; "data.recordId" ) ]
-		If [ Collapsed: OFF ; $errorCode = 0 and not IsEmpty ( $recordId ) ]
+		If [ $errorCode = 0 and not IsEmpty ( $recordId ) ]
 			Enter Find Mode [ Pause: OFF ]
 			Go to Layout [ Layout: "SaXMLDeliveryExecutionContext" ; Animation: None ]
 			Set Field [ SaXMLDelivery::recordId ; $recordId ]
 			Perform Find
-		Else [ Collapsed: OFF ; Collapsed: OFF ]
+		Else
 			Go to Layout [ Layout: "SaXMLDeliveryExecutionContext" ; Animation: None ]
 			Show All Records
 			Show Omitted Only
@@ -75,7 +75,7 @@ End If
 # Validate privilege set - must be full access or must have access via the Data API
 # ■■■■■■■■■■ CONFIGURATION STEP (optional): Customize restrictions to run this script
 Set Variable [ $allowedPrivilegeSet ; Get ( AccountPrivilegeSetName ) = "[Full Access]" or not IsEmpty ( FilterValues ( Get ( AccountExtendedPrivileges ) ; "fmrest" ) ) ]
-If [ Collapsed: OFF ; not $allowedPrivilegeSet ]
+If [ not $allowedPrivilegeSet ]
 	Exit Script [ JSONSetElement ( "" ; [ "errorCode" ; 9 ; JSONNumber ] ; [ "message" ; "Insufficient privileges" ; JSONString ] ) ]
 End If
 
@@ -112,13 +112,13 @@ Set Error Capture [ ON ]
 # ====================================================================================================
 
 # Set up context
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Go to Layout [ Layout: "SaXMLDeliveryExecutionContext" ; Animation: None ]
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 End If
 
 # Purge old records
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	# Delete records older than 3 months
 	Set Variable [ $purgeDate[1] ; Let ( 
 	today = Get ( CurrentDate ) ; 
@@ -127,25 +127,25 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 	Enter Find Mode [ Pause: OFF ]
 	Set Field [ SaXMLDelivery::createTimestamp ; "<" & $purgeDate ]
 	Perform Find
-	If [ Collapsed: OFF ; Get ( FoundCount ) > 0 and Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) // belt and suspenders ]
+	If [ Get ( FoundCount ) > 0 and Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) // belt and suspenders ]
 		Delete All Records [ With dialog: OFF ]
 	End If
 End If
 
 # Create new record
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	New Record/Request
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 End If
 
 # Create SaXML xml file on file system
 # 2024-10-07 mkos: Added support for $_includeDetailsForAnalysisTools
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Set Variable [ $xmlPath ; Get ( TemporaryPath ) & Get ( FileName ) & ".xml" ]
 	Set Variable [ $start ; Get ( CurrentTimeUTCMilliseconds ) ]
-	If [ Collapsed: OFF ; $_includeDetailsForAnalysisTools ]
+	If [ $_includeDetailsForAnalysisTools ]
 		Save a Copy as XML [ Get ( WindowName ) ; ⚠️ PARAMETER "UniversalPathList" NOT PARSED ⚠️ ; Include details for analysis tools: ON ; Save each layout object&apos;s binary data under its node: OFF ]
-	Else [ Collapsed: OFF ; Collapsed: OFF ]
+	Else
 		Save a Copy as XML [ Get ( WindowName ) ; ⚠️ PARAMETER "UniversalPathList" NOT PARSED ⚠️ ; Include details for analysis tools: OFF ; Save each layout object&apos;s binary data under its node: OFF ]
 	End If
 	Set Variable [ $errorCode ; Get ( LastError ) ]
@@ -155,13 +155,13 @@ End If
 # Upload xml file to container field
 # Note, we tried using the Read From Data File step, but it's not any faster, and it makes the code more complex, bc you have to read the file in chunks
 # 2024-07-17 mkos: Don't automatically encode url since ConvertFromFileMakerPath will already do that for us
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Set Variable [ $start ; Get ( CurrentTimeUTCMilliseconds ) ]
 	Insert from URL [ Verify SSL Certificates: OFF ; Select: ON ; With dialog: OFF ; Target: SaXMLDelivery::xmlFile ; ⚠️ PARAMETER "URL" NOT PARSED ⚠️ ]
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 	Set Variable [ $timeToUpload[1] ; GetAsTime ( ( Get ( CurrentTimeUTCMilliseconds ) - $start ) / 1000 ) ]
 End If
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Set Field [ SaXMLDelivery::timeToCreate ; $timeToCreate ]
 	Set Field [ SaXMLDelivery::timeToUpload ; $timeToUpload ]
 	Set Field [ SaXMLDelivery::sizeInBytes ; GetContainerAttribute ( SaXMLDelivery::xmlFile ; "filesize" ) ]
@@ -171,13 +171,13 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 End If
 
 # Delete xml file in temp folder
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Delete File [ ⚠️ PARAMETER "UniversalPathList" NOT PARSED ⚠️ ]
 	Set Variable [ $errorCode ; Get ( LastError ) ]
 End If
 
 # Handle error
-If [ Collapsed: OFF ; $errorCode > 1 and IsEmpty ( $message ) ]
+If [ $errorCode > 1 and IsEmpty ( $message ) ]
 	Set Variable [ $message[1] ; // We would typically use a custom function here, but we wanted this script to have as few dependencies as possible
 /**
  * @SIGNATURE:
@@ -487,7 +487,7 @@ Let ( [
 	
 ) ]
 End If
-If [ Collapsed: OFF ; not IsEmpty ( $message )
+If [ not IsEmpty ( $message )
 and PatternCount ( Get ( ApplicationVersion ) ; "Data API Engine" ) = 0
 and PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 ]
 	Show Custom Dialog [ Message: $message ; Default Button: "OK" ]
@@ -504,8 +504,8 @@ Set Variable [ $data[1] ; JSONSetElement ( $data
 Set Variable [ $result[1] ; JSONSetElement ( "" ; [ "errorCode" ; $errorCode ; JSONNumber ] ; [ "message" ; $message ; JSONString ] ; [ "data" ; $data ; JSONObject ] ) ]
 
 # In case of error, if we were able to get to the layout and create a new record, store $result in the record
-If [ Collapsed: OFF ; $errorCode > 1 ]
-	If [ Collapsed: OFF ; Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) and not IsEmpty ( $recordId ) ]
+If [ $errorCode > 1 ]
+	If [ Get ( LayoutTableName ) = GetValue ( Substitute ( GetFieldName ( SaXMLDelivery::xmlFile ) ; "::" ; ¶ ) ; 1 ) and not IsEmpty ( $recordId ) ]
 		Set Field [ SaXMLDelivery::notes ; Get ( ScriptName ) & " script result:¶" & JSONFormatElements ( $result ) ]
 		Commit Records/Requests [ Skip data entry validation ; With dialog: OFF ]
 	End If
@@ -515,9 +515,9 @@ End If
 # END
 # ====================================================================================================
 
-If [ Collapsed: OFF ; $parentScriptErrorCaptureState ]
+If [ $parentScriptErrorCaptureState ]
 	Set Error Capture [ OFF ]
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+Else
 	Set Error Capture [ OFF ]
 End If
 

--- a/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/SaXMLDelivery - ID 50/saxmlDelivery_runPipeline - ID 53.txt.snap
+++ b/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/SaXMLDelivery - ID 50/saxmlDelivery_runPipeline - ID 53.txt.snap
@@ -44,7 +44,7 @@ Set Variable [ $_silent[1] ; If (
 
 # Validate privilege set - must be full access
 # ■■■■■■■■■■ CONFIGURATION STEP (optional): Customize restrictions to run this script
-If [ Collapsed: OFF ; Get ( AccountPrivilegeSetName ) ≠ "[Full Access]" ]
+If [ Get ( AccountPrivilegeSetName ) ≠ "[Full Access]" ]
 	Exit Script [ JSONSetElement ( "" ; [ "errorCode" ; 9 ; JSONNumber ] ; [ "message" ; "Insufficient privileges" ; JSONString ] ) ]
 End If
 
@@ -82,16 +82,16 @@ Set Variable [ $missingRequired[1] ; List (
 	If ( IsEmpty ( $owner ) ; "git account owner" ) ; 
 	If ( IsEmpty ( FilterValues ( $gitService ; "Bitbucket¶GitHub" ) ) ; "git hosting service" ) ; 
 ) ]
-If [ Collapsed: OFF ; not IsEmpty ( $missingRequired ) ]
+If [ not IsEmpty ( $missingRequired ) ]
 	Set Variable [ $errorCode[1] ; 5 ]
 	Set Variable [ $message[1] ; "Missing config: " & Substitute ( $missingRequired ; ¶ ; ", " ) & "." ]
 End If
 
 # Confirm action
-If [ Collapsed: OFF ; $errorCode = 0 ]
-	If [ Collapsed: OFF ; not $_silent ]
+If [ $errorCode = 0 ]
+	If [ not $_silent ]
 		Show Custom Dialog [ Message: "Run " & $repoName & " pipeline?" ; Default Button: "OK" ; Button 2: "Cancel" ]
-		If [ Collapsed: OFF ; Get ( LastMessageChoice ) ≠ 1 ]
+		If [ Get ( LastMessageChoice ) ≠ 1 ]
 			Set Variable [ $errorCode[1] ; 1 ]
 		End If
 	End If
@@ -99,8 +99,8 @@ End If
 
 # Prep api call
 # 2024-10-07 mkos: @todo add support for an 'includeDetailsForAnalysisTools' parameter by forwarding it to the bitbucket api
-If [ Collapsed: OFF ; $errorCode = 0 ]
-	If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+If [ $errorCode = 0 ]
+	If [ $gitService = "Bitbucket" ]
 		# ref: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-pipelines/#api-repositories-workspace-repo-slug-pipelines-post
 		Set Variable [ $url[1] ; "https://api.bitbucket.org/2.0/repositories/" & $owner & "/" & $repoName & "/pipelines" ]
 		Set Variable [ $requestBody[1] ; JSONSetElement ( "" 
@@ -116,7 +116,7 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 & " --header " & Quote ( "Content-Type: application/json" ) 
 & " --data @$requestBody"
 & " --dump-header $responseHeaders" ]
-	Else [ Collapsed: OFF ; Collapsed: OFF ]
+	Else
 		# GitHub
 		Set Variable [ $url[1] ; "https://api.github.com/repos/" & $owner & "/" & $repoName & "/dispatches" ]
 		Set Variable [ $requestBody[1] ; JSONSetElement ( "" 
@@ -133,7 +133,7 @@ If [ Collapsed: OFF ; $errorCode = 0 ]
 End If
 
 # Make api call to trigger pipeline
-If [ Collapsed: OFF ; $errorCode = 0 ]
+If [ $errorCode = 0 ]
 	Insert from URL [ Verify SSL Certificates: ON ; Select: ON ; With dialog: OFF ; Target: $response ; ⚠️ PARAMETER "URL" NOT PARSED ⚠️ ; $curlOptions ]
 	Set Variable [ $errorCode[1] ; Get ( LastError ) ]
 	Set Variable [ $responseStatusCode[1] ; // We would typically use a custom function here, but we wanted this script to have as few dependencies as possible
@@ -169,7 +169,7 @@ Let ( [
 	GetAsNumber ( code )
 ) ]
 	Set Variable [ $isErrorResponseStatusCode[1] ; not IsEmpty ( $responseStatusCode ) and ( $responseStatusCode < 200 or $responseStatusCode > 299 ) ]
-	If [ Collapsed: OFF ; $gitService = "GitHub" and $errorCode = 10 and not $isErrorResponseStatusCode ]
+	If [ $gitService = "GitHub" and $errorCode = 10 and not $isErrorResponseStatusCode ]
 		# (10) Requested data is missing is expected with GitHub because they do not return a response body
 		Set Variable [ $errorCode[1] ; 0 // reset ]
 	End If
@@ -284,8 +284,8 @@ Let ( [
 End If
 
 # Extract info from success response
-If [ Collapsed: OFF ; $errorCode = 0 and not $isErrorResponseStatusCode ]
-	If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+If [ $errorCode = 0 and not $isErrorResponseStatusCode ]
+	If [ $gitService = "Bitbucket" ]
 		Set Variable [ $buildNumber[1] ; JSONGetElement ( $response ; "build_number" ) ]
 		Set Variable [ $createdOn[1] ; JSONGetElement ( $response ; "created_on" ) ]
 		Set Variable [ $repoUrl[1] ; JSONGetElement ( $response ; "repository.links.html.href" ) ]
@@ -293,8 +293,8 @@ If [ Collapsed: OFF ; $errorCode = 0 and not $isErrorResponseStatusCode ]
 End If
 
 # Build error $message
-If [ Collapsed: OFF ; IsEmpty ( $message ) ]
-	If [ Collapsed: OFF ; $errorCode > 1 ]
+If [ IsEmpty ( $message ) ]
+	If [ $errorCode > 1 ]
 		Set Variable [ $message[1] ; // We would typically use a custom function here, but we wanted this script to have as few dependencies as possible
 /**
  * @SIGNATURE:
@@ -603,7 +603,7 @@ Let ( [
 	"(" & errorCode & ") " & errorMessage 
 	
 ) ]
-	Else If [ Collapsed: OFF ; $isErrorResponseStatusCode ]
+	Else If [ $isErrorResponseStatusCode ]
 		Set Variable [ $errorCode[1] ; 999 & $responseStatusCode ]
 		Set Variable [ $responseStatusMessage[1] ; "(" & $responseStatusCode & ") " & Let ( 
 
@@ -728,29 +728,29 @@ Let ( [
 End If
 
 # Display $message
-If [ Collapsed: OFF ; not $_silent 
+If [ not $_silent 
 and PatternCount ( Get ( ApplicationVersion ) ; "Data API Engine" ) = 0 
 and PatternCount ( Get ( ApplicationVersion ) ; "Server" ) = 0 ]
-	If [ Collapsed: OFF ; $errorCode = 0 ]
-		If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+	If [ $errorCode = 0 ]
+		If [ $gitService = "Bitbucket" ]
 			Set Variable [ $message[1] ; "The " & Quote ( $repoName ) & " pipeline is running build # " & $buildNumber & ". View in browser?" ]
 			Show Custom Dialog [ Message: $message ; Default Button: "Dismiss" ; Button 2: "View" ]
-			If [ Collapsed: OFF ; Get ( LastMessageChoice ) = 2 ]
+			If [ Get ( LastMessageChoice ) = 2 ]
 				Set Variable [ $pipelineBuildUrl[1] ; $repoUrl & "/pipelines/results/" & $buildNumber ]
 				Open URL [ In external browser: OFF ; With dialog: OFF ; ⚠️ PARAMETER "URL" NOT PARSED ⚠️ ]
 			End If
-		Else [ Collapsed: OFF ; Collapsed: OFF ]
+		Else
 			# GitHub
 			Show Custom Dialog [ Message: "The " & Quote ( $repoName ) & " pipeline is running." ; Default Button: "OK" ]
 		End If
-	Else If [ Collapsed: OFF ; not IsEmpty ( $message ) ]
+	Else If [ not IsEmpty ( $message ) ]
 		Show Custom Dialog [ Title: "Error" ; Message: $message ; Default Button: "OK" ]
 	End If
 End If
 
 # Build $data
-If [ Collapsed: OFF ; $errorCode = 0 ]
-	If [ Collapsed: OFF ; $gitService = "Bitbucket" ]
+If [ $errorCode = 0 ]
+	If [ $gitService = "Bitbucket" ]
 		Set Variable [ $data[1] ; JSONSetElement ( $data 
 	; [ "buildNumber" ; $buildNumber ; JSONString ] 
 	; [ "createdOn" ; $createdOn ; JSONString ] 
@@ -764,9 +764,9 @@ End If
 # END
 # ====================================================================================================
 
-If [ Collapsed: OFF ; $parentScriptErrorCaptureState ]
+If [ $parentScriptErrorCaptureState ]
 	Set Error Capture [ OFF ]
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+Else
 	Set Error Capture [ OFF ]
 End If
 

--- a/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/Script from fmSyntaxColorizer - ID 37/All script steps and all options - ID 39.txt.snap
+++ b/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/Script from fmSyntaxColorizer - ID 37/All script steps and all options - ID 39.txt.snap
@@ -51,12 +51,12 @@ Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ;
 Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ; Name: 123 ; ⚠️ PARAMETER "UUID" NOT PARSED ⚠️ ]
 Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ; Name: $BeaconName ; ⚠️ PARAMETER "Latitude" NOT PARSED ⚠️ ; ⚠️ PARAMETER "Longitude" NOT PARSED ⚠️ ; ⚠️ PARAMETER "Radius" NOT PARSED ⚠️ ]
 
-If [ Collapsed: OFF ; 1=0 ]
-Else If [ Collapsed: OFF ; 1=1 ]
-	If [ Collapsed: OFF ]
-	Else If [ Collapsed: OFF ]
+If [ 1=0 ]
+Else If [ 1=1 ]
+	If []
+	Else If []
 	End If
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+Else
 End If
 
 Exit Script []
@@ -68,21 +68,21 @@ Install OnTimer Script
 Install OnTimer Script [ 123 ]
 Install OnTimer Script [ 1+2 ]
 
-Loop [ Collapsed: OFF ; Flush: Always ]
+Loop [ Flush: Always ]
 	Exit Loop If [ 1=1 ]
 End Loop
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 5000 ; ErrorMessage: "Broken" ]
 Commit Transaction
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: OFF ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: OFF ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 5000 ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 5000 ]
 Revert Transaction [ Condition: 1=1 ]
 Commit Transaction
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: ON ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: ON ]
 Revert Transaction [ ErrorCode: 5000 ; ErrorMessage: "Broken" ]
 Commit Transaction
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: ON ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: ON ; Override ESS locking conflicts: ON ]
 Revert Transaction [ Condition: 1=1 ; ErrorCode: 1 ; ErrorMessage: "Broken" ]
 Commit Transaction
 
@@ -229,9 +229,9 @@ Select All
 
 Set Selection [ 🚨🚨🚨 BROKEN REFERENCE 🚨🚨🚨 ; ⚠️ PARAMETER "Select" NOT PARSED ⚠️ ]
 
-Undo/Redo [ Collapsed: OFF ; Toggle ]
-Undo/Redo [ Collapsed: OFF ; Undo ]
-Undo/Redo [ Collapsed: OFF ; Redo ]
+Undo/Redo [ Toggle ]
+Undo/Redo [ Undo ]
+Undo/Redo [ Redo ]
 
 # ===========
 # FIELD STEPS

--- a/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/Scripts With Everything - ID 21/Control - ID 20.txt.snap
+++ b/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/Scripts With Everything - ID 21/Control - ID 20.txt.snap
@@ -5,7 +5,7 @@ expression: output_content
 
 Allow User Abort [ OFF ]
 
-Open Transaction [ Collapsed: OFF ; Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
+Open Transaction [ Skip auto-enter options: OFF ; Skip data entry validation: OFF ; Override ESS locking conflicts: OFF ]
 Set Revert Transaction on Error [ OFF ]
 Revert Transaction
 Commit Transaction
@@ -14,12 +14,12 @@ Configure Local Notification [ ⚠️ PARAMETER "action" NOT PARSED ⚠️ ]
 Configure NFC Reading [ ⚠️ PARAMETER "action" NOT PARSED ⚠️ ]
 Configure Region Monitor Script [ ⚠️ PARAMETER "Monitor" NOT PARSED ⚠️ ]
 
-If [ Collapsed: OFF ]
-Else If [ Collapsed: OFF ]
-Else [ Collapsed: OFF ; Collapsed: OFF ]
+If []
+Else If []
+Else
 End If
 
-Loop [ Collapsed: OFF ; Flush: Always ]
+Loop [ Flush: Always ]
 	Exit Loop If [ True ]
 End Loop
 

--- a/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/Scripts With Everything - ID 21/Editing - ID 24.txt.snap
+++ b/tests/snapshots_domain_lossy/scripts_sanitized/Ooe/Scripts With Everything - ID 21/Editing - ID 24.txt.snap
@@ -10,4 +10,4 @@ Paste [ Select: ON ; No style: ON ]
 Perform Find/Replace [ With dialog: ON ; ⚠️ PARAMETER "perform" NOT PARSED ⚠️ ; ⚠️ PARAMETER "find" NOT PARSED ⚠️ ; ⚠️ PARAMETER "replace" NOT PARSED ⚠️ ; ⚠️ PARAMETER "direction" NOT PARSED ⚠️ ; ⚠️ PARAMETER "case" NOT PARSED ⚠️ ; ⚠️ PARAMETER "whole" NOT PARSED ⚠️ ; ⚠️ PARAMETER "across" NOT PARSED ⚠️ ; ⚠️ PARAMETER "within" NOT PARSED ⚠️ ]
 Select All
 Set Selection [ ⚠️ PARAMETER "Select" NOT PARSED ⚠️ ]
-Undo/Redo [ Collapsed: OFF ; Undo ]
+Undo/Redo [ Undo ]


### PR DESCRIPTION
## Summary

FileMaker's SaXML export now includes `Collapsed` as both an XML attribute on `<Step>`
elements and as a `Boolean` parameter type, reflecting the UI collapse state of blocks
in the Script Workspace. The exploder was surfacing this in sanitized output:

```
If [ Collapsed: OFF ; $errorFind = 401 ]
Else [ Collapsed: OFF ; Collapsed: OFF ]
```

## Fix (two parts)

**`src/utils/xml_utils.rs`** — add `"Collapsed"` to the de-noise filter in
`start_element_to_string`, stripping the attribute from reconstructed XML in normal
(lossy) mode. Preserved in lossless mode.

**`src/script_steps/parameters/boolean.rs`** — return `None` from `display()` when
`Boolean type="Collapsed"`. This is a UI-only visual state that carries no semantic
meaning in the script and should never appear in sanitized output.

## Tests

- `xml_utils.rs`: `test_collapsed_attribute_stripped_in_lossy_mode`, `test_collapsed_attribute_preserved_in_lossless_mode`
- `boolean.rs`: `test_collapsed_returns_none`
- Affected snapshots updated.

Fixes #178
